### PR TITLE
Add pre-commit hook scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,3 +238,18 @@ It's recommended to add this repo as a submodule and make a symlink:
 $ git submodule add git@github.com:flix-tech/objective-c-style-guide.git code-style
 $ ln -s code-style/clang-format .clang-format
 ```
+
+## Git hooks
+
+This repo provides a pre-commit hook for Git. The hook checks if changed lines comply with coding style and
+prevents commit if they don't. Hook assumes that clang-format binary is in the PATH.
+
+Scripts are courtesy of [Badoo](https://github.com/badoo/objective-c-style-guide) and distributed under
+[MIT License](scripts/LICENSE).
+See also the [detailed blog post](https://techblog.badoo.com/blog/2015/09/21/clang-format-as-a-guard-for-objective-c-code-style/) on the matter.
+
+To install pre-commit hook, run the following command:
+
+```bash
+$ code-style/scripts/install_pre_commit_hook.py
+```

--- a/scripts/LICENSE
+++ b/scripts/LICENSE
@@ -1,0 +1,20 @@
+The MIT License (MIT)
+
+Copyright (c) 2015-present Badoo Trading Limited.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/scripts/install_pre_commit_hook.py
+++ b/scripts/install_pre_commit_hook.py
@@ -1,0 +1,45 @@
+#!/usr/bin/python
+
+'''
+The MIT License (MIT)
+Copyright (c) 2015-present Badoo Trading Limited.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+'''
+ 
+import os
+import platform
+import shutil
+
+git_hooks_dir = os.path.abspath(os.path.join(os.getcwd(), '.git/hooks'))
+if not os.path.exists(git_hooks_dir):
+    print 'Created', git_hooks_dir
+    os.makedirs(git_hooks_dir)
+
+pre_commit_hook_dst = os.path.join(git_hooks_dir, 'pre-commit')
+if os.path.islink(pre_commit_hook_dst) or os.path.isfile(pre_commit_hook_dst):
+    print 'Removed previously installed hook'
+    os.remove(pre_commit_hook_dst)
+
+scripts_dir = os.path.split(os.path.abspath(__file__))[0]
+    
+pre_commit_hook_src = os.path.join(scripts_dir,   'pre_commit.py')
+if platform.system() == 'Windows':
+	shutil.copy(pre_commit_hook_src, pre_commit_hook_dst)
+	print 'Installed git hook into', pre_commit_hook_dst
+else:
+	os.symlink(pre_commit_hook_src, pre_commit_hook_dst)
+	print 'Installed git hook into', pre_commit_hook_dst, '~>', pre_commit_hook_src

--- a/scripts/pre_commit.py
+++ b/scripts/pre_commit.py
@@ -1,0 +1,149 @@
+#!/usr/bin/env python
+
+'''
+The MIT License (MIT)
+Copyright (c) 2015-present Badoo Trading Limited.
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.
+'''
+
+import argparse
+import difflib
+import re
+import string
+import subprocess
+import StringIO
+import sys
+import os
+import tempfile
+import platform
+
+is_windows = False
+if platform.system() == 'Windows':
+    is_windows = True
+
+# Check whether line ending is to be fixed on Windows manually as apparently Python's universal newlines, i.e. 'rU' mode for open(), does not work
+needs_line_endings_fix = False
+if is_windows:
+    key_value_match = re.compile(r'^\s*(.+?)\s*=\s*(.+?)\s*$')
+    p = subprocess.Popen(['git', 'config', '--list'], stdout=subprocess.PIPE, stderr=None)
+    stdout, stderr = p.communicate()
+    if p.returncode == 0:
+        lines = StringIO.StringIO(stdout).readlines()
+        for line in lines:
+            mo = key_value_match.search(line)
+            if mo:
+                key = mo.group(1)
+                if key != 'core.autocrlf':
+                    continue
+                value = mo.group(2)
+                if value == 'true':
+                    needs_line_endings_fix = True
+
+binary_name = 'clang-format'
+if is_windows:
+    binary_name = 'clang-format.exe'
+
+binary = binary_name
+patch_prefix = 'com.badoo.codestyle.'
+patch_suffix = '.patch'
+
+def main():
+    # Delete previously generated patches
+    temp_folder = tempfile.gettempdir()
+    for filename in os.listdir(temp_folder):
+        if filename.startswith(patch_prefix) and filename.endswith(patch_suffix):
+            os.remove(os.path.join(temp_folder, filename))
+    
+    # Retrieve changes which are to be committed
+    p = subprocess.Popen(['git', 'diff', '--no-color', '--cached'], stdout=subprocess.PIPE, stderr=None)
+    stdout, stderr = p.communicate()
+    if p.returncode != 0:
+        sys.exit(p.returncode)
+    lines = StringIO.StringIO(stdout).readlines()
+    
+    # Extract changed lines for each file
+    filename = None
+    lines_by_file = {}
+    for line in lines:
+        match = re.search('^\+\+\+\ (.*?/){1}(\S*)', line)
+        if match:
+            filename = match.group(2)
+        if filename == None:
+            continue
+            
+        # Skip unnecessary files
+        if not re.match('^.*\.(h|m|mm)$', filename):
+            continue
+
+        match = re.search('^@@.*\+(\d+)(,(\d+))?', line)
+        if match:
+            start_line = int(match.group(1))
+            line_count = 1
+            if match.group(3):
+                line_count = int(match.group(3))
+            if line_count == 0:
+                continue
+            end_line = start_line + line_count - 1
+            lines_by_file.setdefault(filename, []).extend(['-lines', str(start_line) + ':' + str(end_line)])
+
+    # Reformat files containing changes in place
+    patch_contents = ''
+    for filename, lines in lines_by_file.iteritems():
+        command = [binary, '-style=file', filename]
+        command.extend(lines)
+        p = subprocess.Popen(command, stdout=subprocess.PIPE, stderr=None, stdin=subprocess.PIPE)
+        stdout, stderr = p.communicate()
+        if p.returncode != 0:
+            sys.exit(p.returncode)
+
+        with open(filename) as f:
+            code = f.readlines()
+
+        if needs_line_endings_fix:
+            code_with_fixed_ending = []
+            for code_line in code:
+                code_line_with_fixed_ending = code_line.replace('\n', '\r\n')
+                code_with_fixed_ending.append(code_line_with_fixed_ending)
+            code = code_with_fixed_ending
+
+        formatted_code = StringIO.StringIO(stdout).readlines()
+
+        diff = difflib.unified_diff(code, formatted_code, filename, filename, '(before formatting)', '(after formatting)')
+        diff_string = string.join(diff, '')
+        if len(diff_string) > 0:
+            patch_contents += diff_string
+            if 'STOP_ON_CODESTYLE_ERROR' in os.environ:
+                break
+
+    if len(patch_contents) > 0:
+        temp_patch_file = tempfile.NamedTemporaryFile(prefix=patch_prefix, suffix=patch_suffix, delete=False)
+        temp_patch_file.write(patch_contents)
+        temp_patch_file_path = temp_patch_file.name
+        temp_patch_file.close() # Sync
+        
+        execute_string = 'cat ' + temp_patch_file_path + ' | patch -p0'
+            
+        print 'ERROR: INCORRECT CODE STYLE'
+        print 'If you believe it is correct, use \'-n\' or \'--no-verify\' option to ignore this error.'
+        print 'Otherwise execute \'' + execute_string + '\' to fix found issues.'
+        print 'Do NOT forget to add changes to the index if needed or use \'-a\' option, otherwise they will be lost.'
+
+        print patch_contents
+        sys.exit(1)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
pre-commit hook checks if changed lines comply with coding style and
prevents commit if they don't. Hook assumes that clang-format binary is in the PATH.

Courtesy of Badoo.
- [Blog post](https://techblog.badoo.com/blog/2015/09/21/clang-format-as-a-guard-for-objective-c-code-style/)
- [GitHub](https://github.com/badoo/objective-c-style-guide)
